### PR TITLE
Remove minimum-fold-change parameter from pvacfuse

### DIFF
--- a/lib/binding_filter.py
+++ b/lib/binding_filter.py
@@ -42,15 +42,16 @@ class BindingFilter:
                  + "has ic50 binding scores below this value. Default: 500",
             default=500
         )
-        parser.add_argument(
-            '-c', '--minimum-fold-change', type=int,
-            help="Minimum fold change between mutant binding "
-                 + "score and wild-type score. The default is 0, which "
-                 + "filters no results, but 1 is often a sensible "
-                 + "option (requiring that binding is better to the MT than WT). "
-                 + "Default: 0",
-            default=0
-        )
+        if tool == 'pvacseq':
+            parser.add_argument(
+                '-c', '--minimum-fold-change', type=int,
+                help="Minimum fold change between mutant binding "
+                     + "score and wild-type score. The default is 0, which "
+                     + "filters no results, but 1 is often a sensible "
+                     + "option (requiring that binding is better to the MT than WT). "
+                     + "Default: 0",
+                default=0
+            )
         parser.add_argument(
             '-m', '--top-score-metric',
             choices=['lowest', 'median'],

--- a/lib/run_argument_parser.py
+++ b/lib/run_argument_parser.py
@@ -94,13 +94,6 @@ class PredictionRunArgumentParser(RunArgumentParser):
                  + "Default: median"
         )
         self.parser.add_argument(
-            "-c", "--minimum-fold-change", type=int,
-            default=0,
-            help="Minimum fold change between mutant binding score and wild-type score. "
-                 + "The default is 0, which filters no results, but 1 is often a sensible choice "
-                 + "(requiring that binding is better to the MT than WT). Default: 0",
-        )
-        self.parser.add_argument(
             '--net-chop-threshold', type=float,
             default=0.5,
             help="NetChop prediction threshold. Default: 0.5",
@@ -137,6 +130,13 @@ class PvacseqRunArgumentParser(PredictionRunArgumentParser):
             "-i", "--additional-input-file-list",
             help="yaml file of additional files to be used as inputs, e.g. cufflinks output files. "
                  + "For an example of this yaml file run `pvacseq config_files additional_input_file_list`."
+        )
+        self.parser.add_argument(
+            "-c", "--minimum-fold-change", type=int,
+            default=0,
+            help="Minimum fold change between mutant binding score and wild-type score. "
+                 + "The default is 0, which filters no results, but 1 is often a sensible choice "
+                 + "(requiring that binding is better to the MT than WT). Default: 0",
         )
         self.parser.add_argument(
             '--normal-cov', type=int,

--- a/tools/pvacfuse/run.py
+++ b/tools/pvacfuse/run.py
@@ -62,7 +62,6 @@ def main(args_input = sys.argv[1:]):
         'top_result_per_mutation'   : args.top_result_per_mutation,
         'top_score_metric'          : args.top_score_metric,
         'binding_threshold'         : args.binding_threshold,
-        'minimum_fold_change'       : args.minimum_fold_change,
         'net_chop_method'           : args.net_chop_method,
         'net_chop_threshold'        : args.net_chop_threshold,
         'additional_report_columns' : args.additional_report_columns,


### PR DESCRIPTION
For fusions we not record a WT protein sequence so the WT epitopes are always NA and this parameter for the binding filter is meaningless.