### PR TITLE
Set dtype of Mutation column when reading in pVACbind result for aggregate report creation

### DIFF
--- a/pvactools/lib/aggregate_all_epitopes.py
+++ b/pvactools/lib/aggregate_all_epitopes.py
@@ -454,7 +454,7 @@ class UnmatchedSequenceAggregateAllEpitopes(AggregateAllEpitopes, metaclass=ABCM
         return None
 
     def read_input_file(self, key, used_columns, dtypes):
-        df = (pd.read_csv(self.input_file, delimiter='\t', float_precision='high', low_memory=False, na_values="NA", keep_default_na=False)
+        df = (pd.read_csv(self.input_file, delimiter='\t', float_precision='high', low_memory=False, na_values="NA", keep_default_na=False, dtype={"Mutation": str})
                 [lambda x: (x['Mutation'] == key)])
         return (df, key)
 


### PR DESCRIPTION
If the Mutation column consists of only numbers, reading in the file one mutation at a time would fail because pandas would interpret the Mutation column as int type instead of str and the subsetting logic would evaluate to false (int != str). 