### PR TITLE
Switch to .readthedocs.yaml file for rtd configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,25 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.8"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: docs/requirements.before_install.txt
+   - requirements: requirements.txt
+   - requirements: docs/requirements.txt
+   - method: pip
+     path: .

--- a/docs/requirements.before_install.txt
+++ b/docs/requirements.before_install.txt
@@ -1,0 +1,1 @@
+setuptools==57.4.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,3 @@
 sphinx==3.0.0
-sphinxjp.themes.basicstrap
-sphinxcontrib-programoutput
-pvactools
---install-option="--no-deps"
+sphinxjp.themes.basicstrap==0.5.0
+sphinxcontrib-programoutput==0.17

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,3 +1,0 @@
-python:
-    install:
-        - requirements: docs/requirements.txt


### PR DESCRIPTION
Our documentation builds were running into the same issue as: https://github.com/griffithlab/pVACtools/issues/712. Pinning setuptools to an older version fixes this issue although this step has to be done separately from the step that would lead to the installation of pyvcf (hence the new `docs/requirements.before_install.txt`).