### PR TITLE
Only emit "Variant doesn't have protein position information" warning if the transcript consequence is supported in the first place

### DIFF
--- a/pvactools/lib/input_file_converter.py
+++ b/pvactools/lib/input_file_converter.py
@@ -305,6 +305,11 @@ class VcfConverter(InputFileConverter):
                     transcripts = self.csq_parser.parse_csq_entries_for_allele(entry.INFO['CSQ'], 'deletion')
 
                 for transcript in transcripts:
+                    transcript_name = transcript['Feature']
+                    consequence = self.resolve_consequence(transcript['Consequence'], reference, alt)
+                    if consequence is None:
+                        continue
+
                     if '/' in transcript['Protein_position']:
                         protein_position = transcript['Protein_position'].split('/')[0]
                         if protein_position == '-':
@@ -314,10 +319,7 @@ class VcfConverter(InputFileConverter):
                     if protein_position == '-' or protein_position == '':
                         print("Variant doesn't have protein position information. Skipping.\n{} {} {} {} {}".format(entry.CHROM, entry.POS, entry.REF, alt, transcript['Feature']))
                         continue
-                    transcript_name = transcript['Feature']
-                    consequence = self.resolve_consequence(transcript['Consequence'], reference, alt)
-                    if consequence is None:
-                        continue
+
                     elif consequence == 'FS':
                         if transcript['FrameshiftSequence'] == '':
                             print("frameshift_variant transcript does not contain a FrameshiftSequence. Skipping.\n{} {} {} {} {}".format(entry.CHROM, entry.POS, entry.REF, alt, transcript['Feature']))


### PR DESCRIPTION
This will cut down on noise since consequences like downstream_gene_variant and intron_variant (that can't be processed by pVACseq) don't have the protein position filled in and where clogging the stdout.

Closes #823 