### PR TITLE
Fix the issue if the [transcript_support_level] provided to int could not be parsed as an integer

### DIFF
--- a/pvactools/lib/top_score_filter.py
+++ b/pvactools/lib/top_score_filter.py
@@ -405,7 +405,7 @@ class PvacspliceTopScoreFilter(TopScoreFilter, metaclass=ABCMeta):
             biotype_lines = lines
 
         #subset protein_coding dataset to only include entries with a TSL < maximum_transcript_support_level
-        tsl_lines = [x for x in biotype_lines if x['Transcript Support Level'] != 'NA' and x['Transcript Support Level'] != 'Not Supported' and int(x['Transcript Support Level']) < self.maximum_transcript_support_level]
+        tsl_lines = [x for x in biotype_lines if x['Transcript Support Level'] != 'NA' and x['Transcript Support Level'] != 'Not Supported' and int(float(x['Transcript Support Level'])) < self.maximum_transcript_support_level]
         #if this results in an empty dataset, reset to previous dataset
         if len(tsl_lines) == 0:
             tsl_lines = biotype_lines


### PR DESCRIPTION
Top_score_filter.py Line 408: 

ValueError: invalid literal for int() with base 10: ".

**Solution:** change the string to float fist then int.