### PR TITLE
Fix bugs in pvacseq create_peptide_ordering_form

### DIFF
--- a/pvactools/lib/color_peptides51mer.py
+++ b/pvactools/lib/color_peptides51mer.py
@@ -170,6 +170,8 @@ def generate_formatted_excel(peptides_df, output_path, output_file_prefix, sampl
     for row_idx, row in peptides_df.iterrows():
         for col_idx, header in enumerate(visible_columns):
             value = row[header]
+            if pd.isna(value):
+                value = 'NA'
             if (
                 header
                 == "CANDIDATE NEOANTIGEN AMINO ACID SEQUENCE WITH FLANKING RESIDUES"


### PR DESCRIPTION
This PR fixes two issues:
- If the ID contains a `-` in the gene name, the regex to parse out the gene, transcript, etc was not working as intended
- If the Pos column is a nan (common in frameshifts), writing to the excel worksheet would throw an error. 

To prevent a similar situation from causing downstream errors in the future, this PR also turns the "Unrecognized ID format" log message into a fatal error.

This PR also cleans up some stray whitespaces so it's best viewed with the "hide whitespace" option enabled (`?diff=unified&w=1` appended to the URL).