### PR TITLE
Fix a couple of FASTA creation bugs

### DIFF
--- a/pvactools/lib/fasta_generator.py
+++ b/pvactools/lib/fasta_generator.py
@@ -241,6 +241,8 @@ class FastaGenerator(metaclass=ABCMeta):
 
             if variant_type == 'FS':
                 full_mutant_sequence = line['frameshift_amino_acid_sequence']
+                if full_wildtype_sequence.startswith(full_mutant_sequence):
+                    continue
                 wildtype_subsequence, mutant_subsequence, left_flanking_subsequence = self.get_frameshift_subsequences(position, full_wildtype_sequence, full_mutant_sequence)
                 mutation_start_position = len(left_flanking_subsequence)
                 wildtype_subsequence = self.add_proximal_variants(line['index'], wildtype_subsequence, mutation_start_position, position, True)

--- a/pvactools/lib/pipeline.py
+++ b/pvactools/lib/pipeline.py
@@ -164,6 +164,8 @@ class Pipeline(metaclass=ABCMeta):
         status_message("Converting .%s to TSV" % self.input_file_type)
         if os.path.exists(self.tsv_file_path()):
             status_message("TSV file already exists. Skipping.")
+            if self.phased_proximal_variants_vcf is not None:
+                self.proximal_variants_file = os.path.join(self.output_dir, self.sample_name + '.proximal_variants.tsv')
             return
 
         convert_params = {


### PR DESCRIPTION
Closes #1349 

This PR fixes two issues:

1.  Some frameshift mutations have no VEP-predicted downstream tail. In the issue example, this is because the transcript amino acid sequence:

>MGRARPGQRGPPSPGPAAQPPAPPRRRARSLALLGALLAAAAAAAVRVCARHAEAQAAARQELALKTLGTDGLFLFSSLDTDGDMYISPEEFKPIAEKLTGSCSVTQTGVQWCSHSSLQPQLPWLN<ins>U</ins>SSCLSLLRSTPAASCEEEELPPDPSEETLTIEARFQPLLPETMTKSKDGFLGVSRLALSGLRNWTAAASPSAVFATRHFQPFLPPPGQELGEPWWIIPSELSMFTGYLSNNRFYPPPPKGKEVIIHRLLSMFHPRPFVKTRFAPQGAVACLTAISDFYYTVMFRIHAEFQLSEPPDFPFWFSPAQFTGHIILSKDATHVRDFRLFVPNHRSLNVDMEWLYGASESSNMEVDIGYIPQMELEATGPSVPSVILDEDGSMIDSHLPSGEPLQFVFEEIKWQQELSWEEAARRLEVAMYPFKKVSYLPFTEAFDRAKAENKLVHSILLWGALDDQSCUGSGRTLRETVLESSPILTLLNESFISTWSLVKELEELQNNQENSSHQKLAGLHLEKYSFPVEMMICLPNGTVVHHINANYFLDITSVKPEEIESNLFSFSSTFEDPSTATYMQFLKEGLRRGLPLLQP

  contains a U, resulting in the VEP-predicted mutant sequence getting cut off at the U:
>MGRARPGQRGPPSPGPAAQPPAPPRRRARSLALLGALLAAAAAAAVRVCARHAEAQAAARQELALKTLGTDGLFLFSSLDTDGDMYISPEEFKPIAEKLTGSCSVTQTGVQWCSHSSLQPQLPWLN

  However, the somatic mutation is after the position of the U, resulting an empty mutant sequence to be extracted, which results in downstream errors when trying to evaluate the first position for an unsupported amino acid. These types of variants can be skipped since they don't produce any novel neoantigen candidates.

2. In the process of evaluating a first bug a noticed an oddity where restarting a run that had failed during the fasta creation step would no longer incorporate proximal variants. When a run aborts during the fasta creation step and is then restarted the code tries to pick up where it left off. However, the VCF has already been converted to a TSV and the proximal variants have been extracted to a separate TSV. These two steps are not redone but the already existing proximal variant TSV was not being hooked up correctly and the fasta creation step would run as if that TSV didn't exist. 