### PR TITLE
Remove pdb debugger from output_parser.py

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -28,3 +28,4 @@ Release Notes
    releases/5_4
    releases/5_5
    releases/6_0
+   releases/6_1

--- a/pvactools/lib/output_parser.py
+++ b/pvactools/lib/output_parser.py
@@ -210,9 +210,8 @@ class OutputParser(metaclass=ABCMeta):
         mt_epitope_seq = result['mt_epitope_seq']
         try:
             wt_result      = wt_results[match_position]
-        except:
-            import pdb
-            pdb.set_trace()
+        except KeyError:
+            raise KeyError(f"No wildtype result found at position {match_position} for MT epitope {mt_epitope_seq}")
         wt_epitope_seq = wt_result['wt_epitope_seq']
         result['wt_epitope_position'] = match_position
         total_matches  = self.determine_total_matches(mt_epitope_seq, wt_epitope_seq)


### PR DESCRIPTION
## Summary
- Removes `pdb.set_trace()` debug code left in production in `match_wildtype_and_mutant_entry_for_missense()`
- Replaces the bare `except: pdb.set_trace()` with a proper `KeyError` that includes the missing position and MT epitope sequence for easier debugging

## Problem
Any exception during WT result lookup would freeze execution by dropping into an interactive debugger (`pdb`), making the tool hang indefinitely in production/CI environments.