### PR TITLE
Replace pkg_resources with importlib.metadata

### DIFF
--- a/pvactools/lib/pipeline.py
+++ b/pvactools/lib/pipeline.py
@@ -4,7 +4,7 @@ import shutil
 import sys
 from collections import OrderedDict
 
-import pkg_resources
+import importlib.metadata
 import pymp
 import yaml
 from Bio.Seq import Seq
@@ -53,7 +53,7 @@ class Pipeline(metaclass=ABCMeta):
             with open(log_file, 'r') as log_fh:
                 past_inputs = yaml.load(log_fh, Loader=yaml.FullLoader)
                 current_inputs = self.__dict__
-                current_inputs['pvactools_version'] = pkg_resources.get_distribution("pvactools").version
+                current_inputs['pvactools_version'] = importlib.metadata.version("pvactools")
                 if past_inputs['pvactools_version'] != current_inputs['pvactools_version']:
                     status_message(
                         "Restart to be executed with a different pVACtools version:\n" +
@@ -79,7 +79,7 @@ class Pipeline(metaclass=ABCMeta):
         else:
             with open(log_file, 'w') as log_fh:
                 inputs = self.__dict__
-                inputs['pvactools_version'] = pkg_resources.get_distribution("pvactools").version
+                inputs['pvactools_version'] = importlib.metadata.version("pvactools")
                 yaml.dump(inputs, log_fh, default_flow_style=False)
 
     def get_flurry_state(self):

--- a/pvactools/lib/print_log.py
+++ b/pvactools/lib/print_log.py
@@ -1,7 +1,8 @@
 import os
 import sys
 import yaml
-import pkg_resources
+import importlib.metadata
+
 from pvactools.lib.run_argument_parser import *
 
 
@@ -12,7 +13,7 @@ def print_log(log_dir, args_dict, output_file_prefix):
         with open(log_file, 'r') as log_fh:
             past_inputs = yaml.load(log_fh, Loader=yaml.FullLoader)
             current_inputs = args_dict
-            current_inputs['pvactools_version'] = pkg_resources.get_distribution("pvactools").version
+            current_inputs['pvactools_version'] = importlib.metadata.version("pvactools")
             if past_inputs['pvactools_version'] != current_inputs['pvactools_version']:
                 print('dif inputs!')
                 sys.exit(
@@ -39,5 +40,5 @@ def print_log(log_dir, args_dict, output_file_prefix):
     else:
         with open(log_file, 'w') as log_fh:
             inputs = args_dict
-            inputs['pvactools_version'] = pkg_resources.get_distribution("pvactools").version
+            inputs['pvactools_version'] = importlib.metadata.version("pvactools")
             yaml.dump(inputs, log_fh, default_flow_style=False)


### PR DESCRIPTION
This should remove these warnings:
```
UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
```