### PR TITLE
Revert accidental tdna-cov default value change

### DIFF
--- a/pvactools/lib/run_argument_parser.py
+++ b/pvactools/lib/run_argument_parser.py
@@ -230,12 +230,12 @@ class RunArgumentParser(metaclass=ABCMeta):
             help="Normal Coverage Cutoff. When creating the filtered.tsv report, only include epitopes "
                  + "with a normal read depth above this cutoff.",
             default=5
-        ) 
+        )
         self.parser.add_argument(
             '--tdna-cov', type=int,
             help="Tumor DNA Coverage Cutoff. When creating the filtered.tsv report, only include epitopes "
                  + "with a tumor DNA read depth above this cutoff.",
-            default=1
+            default=10
         )
         self.parser.add_argument(
             '--trna-cov', type=int,


### PR DESCRIPTION
aee321f1c476807de6db939ef719fd437465db8b  (first released in 6.1.0) introduced an accidental change to the tdna-cov default value from 10 to 1. This PR reverts this change.

Closes #1385