### PR TITLE
Add missing argument hook ups in standalone commands

### DIFF
--- a/pvactools/tools/pvacseq/top_score_filter.py
+++ b/pvactools/tools/pvacseq/top_score_filter.py
@@ -19,6 +19,7 @@ def main(args_input = sys.argv[1:]):
         allele_specific_anchors=args.allele_specific_anchors,
         anchor_contribution_threshold=args.anchor_contribution_threshold,
         maximum_transcript_support_level=args.maximum_transcript_support_level,
+        transcript_prioritization_strategy=args.transcript_prioritization_strategy,
     ).execute()
 
 if __name__ == "__main__":

--- a/pvactools/tools/pvacsplice/generate_aggregated_report.py
+++ b/pvactools/tools/pvacsplice/generate_aggregated_report.py
@@ -68,6 +68,11 @@ def define_parser():
         default=5000,
     )
     parser.add_argument(
+        '--aggregate-inclusion-count-limit', type=int,
+        help="Limit neoantigen candidates included in the aggregate report to only the best n candidates per variant. This ensures performance when loading results into pVACview, e.g. for frameshifts with potentially hundreds of predictions.",
+        default=15,
+    )
+    parser.add_argument(
         '-m', '--top-score-metric',
         choices=['lowest', 'median'],
         default='median',
@@ -142,6 +147,7 @@ def main(args_input = sys.argv[1:]):
         top_score_metric=args.top_score_metric,
         top_score_metric2=args.top_score_metric2,
         aggregate_inclusion_binding_threshold=args.aggregate_inclusion_binding_threshold,
+        aggregate_inclusion_count_limit=args.aggregate_inclusion_count_limit,
     ).execute()
     print("Completed")
 

--- a/pvactools/tools/pvacsplice/top_score_filter.py
+++ b/pvactools/tools/pvacsplice/top_score_filter.py
@@ -15,6 +15,7 @@ def main(args_input = sys.argv[1:]):
         top_score_metric=args.top_score_metric,
         top_score_metric2=args.top_score_metric2,
         maximum_transcript_support_level=args.maximum_transcript_support_level,
+        transcript_prioritization_strategy=args.transcript_prioritization_strategy,
     ).execute()
 
 if __name__ == "__main__":


### PR DESCRIPTION
While working on some new features I found a few spots where certain arguments were not hooked up when running some standalone commands.