### PR TITLE
Harden filtering and runtime error handling

### DIFF
--- a/pvactools/lib/filter.py
+++ b/pvactools/lib/filter.py
@@ -1,8 +1,18 @@
 import pandas as pd
 import csv
+import operator
 import sys
 
 pd.options.mode.chained_assignment = None
+
+FILTER_OPERATORS = {
+    "<": operator.lt,
+    "<=": operator.le,
+    "==": operator.eq,
+    "!=": operator.ne,
+    ">=": operator.ge,
+    ">": operator.gt,
+}
 
 class Filter:
     def __init__(self, input_file, output_file, filter_criteria, int_filter_columns=[], filter_strategy="AND"):
@@ -20,13 +30,23 @@ class Filter:
             for line in reader:
                 to_filter = False
 
-                process_criterion = lambda criterion: (
-                    (line[criterion.column] != 'NA' and criterion.skip_value != line[criterion.column] and not eval("{} {} {}".format(
-                        line[criterion.column] if line[criterion.column] != 'inf' else sys.maxsize,
-                        criterion.operator,
-                        criterion.threshold
-                    )))
-                )
+                def process_criterion(criterion):
+                    value = line[criterion.column]
+                    if value == 'NA' or criterion.skip_value == value:
+                        return False
+                    if value == 'inf':
+                        numeric_value = sys.maxsize
+                    else:
+                        try:
+                            numeric_value = float(value)
+                        except (TypeError, ValueError):
+                            raise ValueError(
+                                "Invalid numeric value {!r} for filter column {!r}.".format(
+                                    value,
+                                    criterion.column,
+                                )
+                            )
+                    return not criterion.comparator(numeric_value, criterion.threshold)
 
                 if self.filter_strategy == "AND":
                     to_filter = any(process_criterion(criterion) for criterion in self.filter_criteria)
@@ -38,7 +58,24 @@ class Filter:
 
 class FilterCriterion:
     def __init__(self, column, operator, threshold, skip_value=None):
+        if operator not in FILTER_OPERATORS:
+            raise ValueError(
+                "Unsupported filter operator {!r}. Supported operators are: {}.".format(
+                    operator,
+                    ", ".join(FILTER_OPERATORS),
+                )
+            )
+        try:
+            numeric_threshold = float(threshold)
+        except (TypeError, ValueError):
+            raise ValueError(
+                "Invalid numeric threshold {!r} for filter column {!r}.".format(
+                    threshold,
+                    column,
+                )
+            )
         self.column = column
         self.operator = operator
-        self.threshold = threshold
+        self.comparator = FILTER_OPERATORS[operator]
+        self.threshold = numeric_threshold
         self.skip_value = skip_value

--- a/pvactools/lib/output_parser.py
+++ b/pvactools/lib/output_parser.py
@@ -565,11 +565,19 @@ class OutputParser(metaclass=ABCMeta):
         #The WT epitope at the same position is the match
         match_position = mt_position
         mt_epitope_seq = result['mt_epitope_seq']
-        try:
-            wt_result      = wt_results[match_position]
-        except:
-            import pdb
-            pdb.set_trace()
+        if match_position not in wt_results:
+            available_positions = ', '.join(
+                sorted(str(position) for position in wt_results)
+            ) or 'none'
+            raise ValueError(
+                "Unable to match missense mutant epitope to a wildtype epitope "
+                f"at position {match_position} for TSV index "
+                f"{result.get('tsv_index', 'unknown')} (allele "
+                f"{result.get('allele', 'unknown')}, mutant epitope "
+                f"{mt_epitope_seq}). Available wildtype positions: "
+                f"{available_positions}."
+            )
+        wt_result = wt_results[match_position]
         wt_epitope_seq = wt_result['wt_epitope_seq']
         result['wt_epitope_position'] = match_position
         total_matches  = self.determine_total_matches(mt_epitope_seq, wt_epitope_seq)

--- a/pvactools/lib/run_utils.py
+++ b/pvactools/lib/run_utils.py
@@ -216,22 +216,40 @@ def get_mutated_frameshift_peptide_with_flanking_sequence(wt_peptide, mt_peptide
         return
     return mutant_subsequence
 
+def _parse_transcript_boolean(value, column):
+    if pd.api.types.is_bool(value):
+        return bool(value)
+    if isinstance(value, str):
+        if value == 'True':
+            return True
+        if value == 'False':
+            return False
+        if value == 'Not Run':
+            return value
+    raise ValueError(
+        "Invalid value {!r} for {!r}. Expected True, False, or 'Not Run'.".format(
+            value,
+            column,
+        )
+    )
+
 def is_preferred_transcript(mutation, transcript_prioritization_strategy, maximum_transcript_support_level):
     if not isinstance(mutation, pd.Series):
         mutation = pd.Series(mutation)
-        if mutation['Canonical'] != 'Not Run':
-            mutation['Canonical'] = eval(mutation['Canonical'])
-        if mutation['MANE Select'] != 'Not Run':
-            mutation['MANE Select'] = eval(mutation['MANE Select'])
+        canonical = _parse_transcript_boolean(mutation['Canonical'], 'Canonical')
+        mane_select = _parse_transcript_boolean(mutation['MANE Select'], 'MANE Select')
+    else:
+        canonical = mutation['Canonical']
+        mane_select = mutation['MANE Select']
     if 'mane_select' in transcript_prioritization_strategy:
-        if mutation['MANE Select'] == 'Not Run':
+        if mane_select == 'Not Run':
             return True
-        elif mutation['MANE Select']:
+        elif mane_select:
             return True
     if 'canonical' in transcript_prioritization_strategy:
-        if mutation['Canonical'] == 'Not Run':
+        if canonical == 'Not Run':
             return True
-        elif mutation['Canonical']:
+        elif canonical:
             return True
     if 'tsl' in transcript_prioritization_strategy:
         col = 'TSL' if 'TSL' in mutation else 'Transcript Support Level'

--- a/pvactools/tools/main.py
+++ b/pvactools/tools/main.py
@@ -73,12 +73,11 @@ def main():
     if args[0].version is True:
         print(version('pvactools'))
     else:
-        try:
-            args[0].func.main(args[1])
-        except AttributeError as e:
+        if not hasattr(args[0], 'func'):
             parser.print_help()
             print("Error: No command specified")
             sys.exit(-1)
+        args[0].func.main(args[1])
 
 
 if __name__ == '__main__':

--- a/pvactools/tools/pvacbind/main.py
+++ b/pvactools/tools/pvacbind/main.py
@@ -93,12 +93,11 @@ def define_parser():
 def main():
     parser = define_parser()
     args = parser.parse_known_args()
-    try:
-        args[0].func.main(args[1])
-    except AttributeError as e:
+    if not hasattr(args[0], 'func'):
         parser.print_help()
         print("Error: No command specified")
         sys.exit(-1)
+    args[0].func.main(args[1])
 
 
 if __name__ == '__main__':

--- a/pvactools/tools/pvacfuse/main.py
+++ b/pvactools/tools/pvacfuse/main.py
@@ -110,12 +110,11 @@ def define_parser():
 def main():
     parser = define_parser()
     args = parser.parse_known_args()
-    try:
-        args[0].func.main(args[1])
-    except AttributeError as e:
+    if not hasattr(args[0], 'func'):
         parser.print_help()
         print("Error: No command specified")
         sys.exit(-1)
+    args[0].func.main(args[1])
 
 if __name__ == '__main__':
     main()

--- a/pvactools/tools/pvacseq/main.py
+++ b/pvactools/tools/pvacseq/main.py
@@ -140,12 +140,11 @@ def define_parser():
 def main():
     parser = define_parser()
     args = parser.parse_known_args()
-    try:
-        args[0].func.main(args[1])
-    except AttributeError as e:
+    if not hasattr(args[0], 'func'):
         parser.print_help()
         print("Error: No command specified")
         sys.exit(-1)
+    args[0].func.main(args[1])
 
 
 if __name__ == '__main__':

--- a/pvactools/tools/pvacsplice/main.py
+++ b/pvactools/tools/pvacsplice/main.py
@@ -120,12 +120,11 @@ def define_parser():
 def main():
     parser = define_parser()
     args = parser.parse_known_args()
-    try:
-        args[0].func.main(args[1])
-    except AttributeError as e:
+    if not hasattr(args[0], 'func'):
         parser.print_help()
         print("Error: No command specified")
         sys.exit(-1)
+    args[0].func.main(args[1])
 
 
 if __name__ == '__main__':

--- a/pvactools/tools/pvacvector/main.py
+++ b/pvactools/tools/pvacvector/main.py
@@ -32,12 +32,11 @@ def define_parser():
 def main():
     parser = define_parser()
     args = parser.parse_known_args()
-    try:
-        args[0].func.main(args[1])
-    except AttributeError as e:
+    if not hasattr(args[0], 'func'):
         parser.print_help()
         print("Error: No command specified")
         sys.exit(-1)
+    args[0].func.main(args[1])
 
 if __name__ == '__main__':
     main()

--- a/pvactools/tools/pvacview/main.py
+++ b/pvactools/tools/pvacview/main.py
@@ -22,12 +22,11 @@ def define_parser():
 def main():
     parser = define_parser()
     args = parser.parse_known_args()
-    try:
-        args[0].func.main(args[1])
-    except AttributeError as e:
+    if not hasattr(args[0], 'func'):
         parser.print_help()
         print("Error: No command specified")
         sys.exit(-1)
+    args[0].func.main(args[1])
 
 
 if __name__ == '__main__':

--- a/tests/test_cli_error_handling.py
+++ b/tests/test_cli_error_handling.py
@@ -1,0 +1,50 @@
+from contextlib import redirect_stdout
+import importlib
+from io import StringIO
+import sys
+import unittest
+from unittest.mock import patch
+
+
+CLI_COMMANDS = [
+    ('pvactools.tools.main', 'valid_alleles'),
+    ('pvactools.tools.pvacseq.main', 'run'),
+    ('pvactools.tools.pvacbind.main', 'run'),
+    ('pvactools.tools.pvacfuse.main', 'run'),
+    ('pvactools.tools.pvacsplice.main', 'run'),
+    ('pvactools.tools.pvacvector.main', 'run'),
+    ('pvactools.tools.pvacview.main', 'run'),
+]
+
+
+class CliErrorHandlingTests(unittest.TestCase):
+    def test_command_attribute_errors_are_not_hidden(self):
+        for module_name, command in CLI_COMMANDS:
+            with self.subTest(module=module_name):
+                cli_module = importlib.import_module(module_name)
+                command_module = getattr(cli_module, command)
+                argv = [module_name, command]
+                error = AttributeError('business failure')
+                with patch.object(sys, 'argv', argv), patch.object(
+                    command_module,
+                    'main',
+                    side_effect=error,
+                ):
+                    with self.assertRaises(AttributeError) as context:
+                        cli_module.main()
+                self.assertIs(context.exception, error)
+
+    def test_missing_commands_report_cli_error(self):
+        for module_name, _ in CLI_COMMANDS:
+            with self.subTest(module=module_name):
+                cli_module = importlib.import_module(module_name)
+                output = StringIO()
+                with patch.object(sys, 'argv', [module_name]), redirect_stdout(output):
+                    with self.assertRaises(SystemExit) as context:
+                        cli_module.main()
+                self.assertEqual(context.exception.code, -1)
+                self.assertIn('Error: No command specified', output.getvalue())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -76,6 +76,22 @@ class FilterTests(unittest.TestCase):
             False
         ))
 
+    def test_not_equal(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            input_file = os.path.join(tmp_dir, "input.tsv")
+            output_file = os.path.join(tmp_dir, "output.tsv")
+            with open(input_file, "w") as input_fh:
+                input_fh.write("Score\n499\n500\n")
+
+            self.assertFalse(Filter(
+                input_file,
+                output_file,
+                [FilterCriterion("Score", "!=", "500")],
+            ).execute())
+
+            with open(output_file) as output_fh:
+                self.assertEqual("Score\n499\n", output_fh.read())
+
     def test_greater_or_equal(self):
         output_file = tempfile.NamedTemporaryFile()
         self.assertFalse(Filter(
@@ -155,6 +171,32 @@ class FilterTests(unittest.TestCase):
             os.path.join(self.test_data_path, "output.inf.tsv"),
             False
         ))
+
+    def test_invalid_operator(self):
+        with self.assertRaisesRegex(ValueError, "Unsupported filter operator"):
+            FilterCriterion(
+                "Median MT IC50 Score",
+                "__import__('os').system('true')",
+                "500",
+            )
+
+    def test_malicious_value_is_not_executed(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            marker_file = os.path.join(tmp_dir, "executed")
+            input_file = os.path.join(tmp_dir, "input.tsv")
+            output_file = os.path.join(tmp_dir, "output.tsv")
+            malicious_value = "__import__('pathlib').Path({!r}).touch() or 1".format(marker_file)
+            with open(input_file, "w") as input_fh:
+                input_fh.write("Score\n{}\n".format(malicious_value))
+
+            with self.assertRaisesRegex(ValueError, "Invalid numeric value"):
+                Filter(
+                    input_file,
+                    output_file,
+                    [FilterCriterion("Score", "<", "500")],
+                ).execute()
+
+            self.assertFalse(os.path.exists(marker_file))
 
     def test_conservative(self):
         output_file = tempfile.NamedTemporaryFile()

--- a/tests/test_output_parser_error_handling.py
+++ b/tests/test_output_parser_error_handling.py
@@ -1,0 +1,43 @@
+import unittest
+
+from pvactools.lib.output_parser import DefaultOutputParser
+
+
+class OutputParserErrorHandlingTests(unittest.TestCase):
+    def test_missing_missense_wildtype_match_raises_contextual_error(self):
+        parser = DefaultOutputParser(
+            input_iedb_files=[],
+            input_tsv_file=None,
+            key_file=None,
+            output_file=None,
+            sample_name='test',
+        )
+        result = {
+            'allele': 'HLA-A*02:01',
+            'mt_epitope_seq': 'ABCDEFGHI',
+            'tsv_index': '1.GENE.TRANSCRIPT.missense.10A/T',
+        }
+        wt_results = {
+            '2': {'wt_epitope_seq': 'ABXDEFGHI'},
+            '3': {'wt_epitope_seq': 'ABCXEFGHI'},
+        }
+
+        with self.assertRaisesRegex(
+            ValueError,
+            (
+                r'position 1.*TSV index '
+                r'1\.GENE\.TRANSCRIPT\.missense\.10A/T.*'
+                r'HLA-A\*02:01.*ABCDEFGHI.*'
+                r'Available wildtype positions: 2, 3'
+            ),
+        ):
+            parser.match_wildtype_and_mutant_entry_for_missense(
+                result,
+                '1',
+                wt_results,
+                None,
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_run_utils.py
+++ b/tests/test_run_utils.py
@@ -67,3 +67,55 @@ class RunUtilsTests(unittest.TestCase):
             checker("102.0")
 
         self.assertEqual("must be in range [0.0 .. 100.0]", str(context.exception))
+
+    def test_is_preferred_transcript_accepts_boolean_values_and_strings(self):
+        for column, strategy in [
+            ('Canonical', 'canonical'),
+            ('MANE Select', 'mane_select'),
+        ]:
+            for value, expected in [
+                (True, True),
+                (False, False),
+                ('True', True),
+                ('False', False),
+                ('Not Run', True),
+            ]:
+                with self.subTest(column=column, value=value):
+                    mutation = {
+                        'Canonical': False,
+                        'MANE Select': False,
+                    }
+                    mutation[column] = value
+                    self.assertEqual(
+                        expected,
+                        is_preferred_transcript(mutation, [strategy], 1),
+                    )
+
+    def test_is_preferred_transcript_rejects_invalid_boolean_value(self):
+        for column, strategy in [
+            ('Canonical', 'canonical'),
+            ('MANE Select', 'mane_select'),
+        ]:
+            with self.subTest(column=column):
+                mutation = {
+                    'Canonical': False,
+                    'MANE Select': False,
+                }
+                mutation[column] = 'yes'
+                with self.assertRaises(ValueError) as context:
+                    is_preferred_transcript(mutation, [strategy], 1)
+                self.assertEqual(
+                    "Invalid value 'yes' for {!r}. Expected True, False, or 'Not Run'.".format(column),
+                    str(context.exception),
+                )
+
+    def test_is_preferred_transcript_does_not_execute_malicious_value(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            marker_file = os.path.join(tmp_dir, "executed")
+            mutation = {
+                'Canonical': "__import__('pathlib').Path({!r}).touch() or True".format(marker_file),
+                'MANE Select': False,
+            }
+            with self.assertRaisesRegex(ValueError, "Invalid value"):
+                is_preferred_transcript(mutation, ['canonical'], 1)
+            self.assertFalse(os.path.exists(marker_file))


### PR DESCRIPTION
## Summary

- replace dynamic `eval()` calls in filtering and transcript prioritization with explicit operator and boolean parsing
- preserve command-level `AttributeError` exceptions instead of treating them as missing CLI commands
- replace a production debugger breakpoint in missense output parsing with a contextual error
- add regression coverage for malicious input, CLI error propagation, and missense matching failures

## Why

Several runtime paths relied on dynamic evaluation or overly broad exception handling. This could execute untrusted TSV content, mask real command failures, or leave production runs in a debugger.

## Impact

Valid inputs retain their existing behavior while invalid filter criteria and transcript flags now fail deterministically with actionable errors. Unexpected command failures propagate to callers, and inconsistent missense output now reports the missing position and available context.

## Validation

- 23 focused regression tests for the changes in this PR passed
- 28 existing output parser regression tests passed
- 3 targeted integration tests for the fixes merged in #1433 and #1434 passed after rebasing
- Python compile check passed for `pvactools` and `tests`
- `pip check` reported no broken requirements
- diff whitespace check passed

## Follow-up

This branch was rebased onto `upstream/master` at v7.1.1. Changes already merged through #1433 and #1434 were removed from this PR.
