### PR TITLE
Fix bug in lowexpr logic

### DIFF
--- a/pvactools/lib/update_tiers.py
+++ b/pvactools/lib/update_tiers.py
@@ -365,7 +365,7 @@ class PvacseqUpdateTiers(UpdateTiers, metaclass=ABCMeta):
 
         #relax expression.  Include sites that have reasonable vaf but zero overall gene expression
         lowexpr=False
-        if mutation['RNA VAF'] != 'NA' and mutation['RNA Expr'] != 'NA' and ['RNA Depth'] != 'NA' and mutation['Allele Expr'] != 'NA':
+        if mutation['RNA VAF'] != 'NA' and mutation['RNA Expr'] != 'NA' and mutation['RNA Depth'] != 'NA' and mutation['Allele Expr'] != 'NA':
             if ((float(mutation["Allele Expr"]) > 0) or
                (float(mutation["RNA Expr"]) == 0 and
                float(mutation["RNA Depth"]) > self.trna_cov and
@@ -715,7 +715,7 @@ class PvacspliceUpdateTiers(UpdateTiers, metaclass=ABCMeta):
 
         #relax expression.  Include sites that have reasonable vaf but zero overall gene expression
         lowexpr=False
-        if mutation['RNA VAF'] != 'NA' and mutation['RNA Expr'] != 'NA' and ['RNA Depth'] != 'NA' and mutation['Allele Expr'] != 'NA':
+        if mutation['RNA VAF'] != 'NA' and mutation['RNA Expr'] != 'NA' and mutation['RNA Depth'] != 'NA' and mutation['Allele Expr'] != 'NA':
             if ((float(mutation["Allele Expr"]) > 0) or
                (float(mutation["RNA Expr"]) == 0 and
                float(mutation["RNA Depth"]) > self.trna_cov and

--- a/tests/test_update_tiers.py
+++ b/tests/test_update_tiers.py
@@ -1,6 +1,7 @@
 import unittest
 import unittest.mock
 import os
+import csv
 import tempfile
 from filecmp import cmp
 import sys
@@ -59,6 +60,49 @@ class UpdateTiersTests(unittest.TestCase):
             os.path.join(self.test_data_dir, "HCC1395.pvacsplice.all_epitopes.aggregated.out.tsv"),
         ))
         tmp_input_file.close()
+
+    def test_pvacseq_missing_rna_depth_is_not_low_expression(self):
+        input_file = os.path.join(self.test_data_dir, 'HCC1395.all_epitopes.aggregated.tsv')
+        with open(input_file) as input_fh:
+            mutation = next(csv.DictReader(input_fh, delimiter='\t'))
+        mutation.update({
+            'IC50 MT': '1',
+            'IC50 %ile MT': '1',
+            'IM %ile MT': '1',
+            'Pres %ile MT': '1',
+            'RNA Expr': '0',
+            'RNA VAF': '0.5',
+            'Allele Expr': '0',
+            'RNA Depth': 'NA',
+            'DNA VAF': '1',
+        })
+
+        updater = PvacseqUpdateTiers(input_file, 0.5)
+        updater.anchor_calculator.is_anchor_residue_pass = unittest.mock.Mock(return_value=True)
+        self.addCleanup(updater.output_file.close)
+
+        self.assertEqual(updater.get_tier(mutation), 'NoExpr')
+
+    def test_pvacsplice_missing_rna_depth_is_not_low_expression(self):
+        input_file = os.path.join(self.test_data_dir, 'HCC1395.pvacsplice.all_epitopes.aggregated.tsv')
+        with open(input_file) as input_fh:
+            mutation = next(csv.DictReader(input_fh, delimiter='\t'))
+        mutation.update({
+            'IC50 MT': '1',
+            'IC50 %ile MT': '1',
+            'IM %ile MT': '1',
+            'Pres %ile MT': '1',
+            'RNA Expr': '0',
+            'RNA VAF': '0.5',
+            'Allele Expr': '0',
+            'RNA Depth': 'NA',
+            'DNA VAF': '1',
+        })
+
+        updater = PvacspliceUpdateTiers(input_file, 0.5)
+        self.addCleanup(updater.output_file.close)
+
+        self.assertEqual(updater.get_tier(mutation), 'NoExpr')
 
     def test_update_tiers_pvacbind(self):
         input_file = os.path.join(self.test_data_dir, 'pvacbind.aggregated.tsv')


### PR DESCRIPTION
This PR incorporates the bugfix regarding the LowExpr tier logic first discovered in #1430. This PR separates it out so that it can be incorporated separately from the other changes proposed in #1430. 