### PR TITLE
Fix tbi file existence check in pVACsplice runs

### DIFF
--- a/pvactools/tools/pvacsplice/run.py
+++ b/pvactools/tools/pvacsplice/run.py
@@ -116,7 +116,7 @@ def main(args_input = sys.argv[1:]):
     if Path(args.annotated_vcf).suffix != '.vcf' and not is_gz_file(args.annotated_vcf):
         sys.exit('The vcf input path does not point to a vcf file.')
     # vcf gz.tbi index file
-    if is_gz_file(args.annotated_vcf) and not Path(f'{args.annotated_vcf}.tbi'):
+    if is_gz_file(args.annotated_vcf) and not Path(f'{args.annotated_vcf}.tbi').exists():
         sys.exit('Gzipped VCF files must be indexed. (tabix -p vcf <vcf_file>)')
     # iedb retries - default 5
     if args.iedb_retries > 100:

--- a/tests/test_pvacsplice.py
+++ b/tests/test_pvacsplice.py
@@ -90,6 +90,33 @@ class PvacspliceTests(unittest.TestCase):
         ))
         self.assertTrue(compiled_run_path)
 
+    def test_gzipped_vcf_requires_tabix_index(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            annotated_vcf = os.path.join(tmp_dir, 'annotated.vcf.gz')
+            with open(os.path.join(self.test_data_directory, 'inputs', 'short_sequence.vcf.gz'), 'rb') as source_fh, open(annotated_vcf, 'wb') as output_fh:
+                copyfileobj(source_fh, output_fh)
+
+            ref_fasta = os.path.join(tmp_dir, 'reference.fa')
+            with open(ref_fasta, 'w') as output_fh:
+                output_fh.write('>chr1\nA\n')
+
+            with self.assertRaises(SystemExit) as cm:
+                run.main([
+                    os.path.join(self.test_data_directory, 'inputs', 'splice_junctions_chr1.tsv'),
+                    'test',
+                    'HLA-G*01:09',
+                    'NetMHC',
+                    tmp_dir,
+                    annotated_vcf,
+                    ref_fasta,
+                    self.gtf_file_chr1,
+                ])
+
+            self.assertEqual(
+                str(cm.exception),
+                'Gzipped VCF files must be indexed. (tabix -p vcf <vcf_file>)',
+            )
+
     def test_pvacsplice_pipeline_class_I(self):
         with patch('pvactools.lib.call_iedb.requests.post', unittest.mock.Mock(side_effect = lambda url, data, files=None: make_response(
             data,


### PR DESCRIPTION
This PR incorporates the bugfix regarding an incorrect file existence check first discovered in https://github.com/griffithlab/pVACtools/pull/1430. This PR separates it out so that it can be incorporated separately from the other changes proposed in https://github.com/griffithlab/pVACtools/pull/1430.