### PR TITLE
Use tmp files in pvac update_tiers tests

### DIFF
--- a/tests/test_pvacbind_update_tiers.py
+++ b/tests/test_pvacbind_update_tiers.py
@@ -5,6 +5,8 @@ import sys
 import py_compile
 from subprocess import PIPE
 from subprocess import run as subprocess_run
+import shutil
+import tempfile
 
 from pvactools.tools.pvacbind import *
 from tests.utils import *
@@ -53,4 +55,7 @@ class PvacbindUpdateTiersTests(unittest.TestCase):
 
     def test_runs(self):
         input_file = os.path.join(self.test_data_directory, 'MHC_Class_I', 'Test.MHC_I.all_epitopes.aggregated.tsv')
-        self.assertFalse(update_tiers.main([input_file]))
+        tmp_input_file = tempfile.NamedTemporaryFile()
+        shutil.copy(input_file, tmp_input_file.name)
+        self.assertFalse(update_tiers.main([tmp_input_file.name]))
+        os.unlink(tmp_input_file.name)

--- a/tests/test_pvacfuse_update_tiers.py
+++ b/tests/test_pvacfuse_update_tiers.py
@@ -5,6 +5,8 @@ import sys
 import py_compile
 from subprocess import PIPE
 from subprocess import run as subprocess_run
+import shutil
+import tempfile
 
 from pvactools.tools.pvacfuse import *
 from tests.utils import *
@@ -53,4 +55,7 @@ class PvacfuseUpdateTiersTests(unittest.TestCase):
 
     def test_runs(self):
         input_file = os.path.join(self.test_data_directory, 'arriba_fusions', 'MHC_Class_I', 'Test.MHC_I.all_epitopes.aggregated.tsv')
-        self.assertFalse(update_tiers.main([input_file]))
+        tmp_input_file = tempfile.NamedTemporaryFile()
+        shutil.copy(input_file, tmp_input_file.name)
+        self.assertFalse(update_tiers.main([tmp_input_file.name]))
+        os.unlink(tmp_input_file.name)

--- a/tests/test_pvacseq_update_tiers.py
+++ b/tests/test_pvacseq_update_tiers.py
@@ -5,6 +5,8 @@ import sys
 import py_compile
 from subprocess import PIPE
 from subprocess import run as subprocess_run
+import shutil
+import tempfile
 
 from pvactools.tools.pvacseq import *
 from tests.utils import *
@@ -54,4 +56,10 @@ class PvacseqUpdateTiersTests(unittest.TestCase):
     def test_runs(self):
         input_file = os.path.join(self.test_data_directory, 'MHC_Class_I', 'Test.MHC_I.all_epitopes.aggregated.tsv')
         input_metrics_file = os.path.join(self.test_data_directory, 'MHC_Class_I', 'Test.MHC_I.all_epitopes.aggregated.metrics.json')
-        self.assertFalse(update_tiers.main([input_file, input_metrics_file, "0.5", "--top-score-metric2", "ic50"]))
+        tmp_input_file = tempfile.NamedTemporaryFile()
+        tmp_input_metrics_file = tempfile.NamedTemporaryFile()
+        shutil.copy(input_file, tmp_input_file.name)
+        shutil.copy(input_metrics_file, tmp_input_metrics_file.name)
+        self.assertFalse(update_tiers.main([tmp_input_file.name, tmp_input_metrics_file.name, "0.5", "--top-score-metric2", "ic50"]))
+        os.unlink(tmp_input_file.name)
+        os.unlink(tmp_input_metrics_file.name)

--- a/tests/test_pvacsplice_update_tiers.py
+++ b/tests/test_pvacsplice_update_tiers.py
@@ -5,6 +5,8 @@ import sys
 import py_compile
 from subprocess import PIPE
 from subprocess import run as subprocess_run
+import shutil
+import tempfile
 
 from pvactools.tools.pvacsplice import *
 from tests.utils import *
@@ -53,4 +55,7 @@ class PvacspliceUpdateTiersTests(unittest.TestCase):
 
     def test_runs(self):
         input_file = os.path.join(self.test_data_directory, 'results', 'run', 'MHC_Class_I', 'HCC1395_TUMOR_DNA.MHC_I.all_epitopes.aggregated.tsv')
-        self.assertFalse(update_tiers.main([input_file, "0.5"]))
+        tmp_input_file = tempfile.NamedTemporaryFile()
+        shutil.copy(input_file, tmp_input_file.name)
+        self.assertFalse(update_tiers.main([tmp_input_file.name, "0.5"]))
+        os.unlink(tmp_input_file.name)


### PR DESCRIPTION
The update tiers commands overwrite/update the input files. The pvacseq|bind|fuse|splice update tiers set were using the same input files as the run tests which could lead to collisions if the update tiers tests ended up updating the files. This PR updates the tests to first copy the input files to tmp files so that the original input files not longer get modified.