### PR TITLE
Replace dynamic evaluation in filtering

### DIFF
--- a/pvactools/lib/filter.py
+++ b/pvactools/lib/filter.py
@@ -1,8 +1,18 @@
 import pandas as pd
 import csv
+import operator
 import sys
 
 pd.options.mode.chained_assignment = None
+
+FILTER_OPERATORS = {
+    "<": operator.lt,
+    "<=": operator.le,
+    "==": operator.eq,
+    "!=": operator.ne,
+    ">=": operator.ge,
+    ">": operator.gt,
+}
 
 class Filter:
     def __init__(self, input_file, output_file, filter_criteria, int_filter_columns=[], filter_strategy="AND"):
@@ -20,13 +30,23 @@ class Filter:
             for line in reader:
                 to_filter = False
 
-                process_criterion = lambda criterion: (
-                    (line[criterion.column] != 'NA' and criterion.skip_value != line[criterion.column] and not eval("{} {} {}".format(
-                        line[criterion.column] if line[criterion.column] != 'inf' else sys.maxsize,
-                        criterion.operator,
-                        criterion.threshold
-                    )))
-                )
+                def process_criterion(criterion):
+                    value = line[criterion.column]
+                    if value == 'NA' or criterion.skip_value == value:
+                        return False
+                    if value == 'inf':
+                        numeric_value = sys.maxsize
+                    else:
+                        try:
+                            numeric_value = float(value)
+                        except (TypeError, ValueError):
+                            raise ValueError(
+                                "Invalid numeric value {!r} for filter column {!r}.".format(
+                                    value,
+                                    criterion.column,
+                                )
+                            )
+                    return not criterion.comparator(numeric_value, criterion.threshold)
 
                 if self.filter_strategy == "AND":
                     to_filter = any(process_criterion(criterion) for criterion in self.filter_criteria)
@@ -38,7 +58,24 @@ class Filter:
 
 class FilterCriterion:
     def __init__(self, column, operator, threshold, skip_value=None):
+        if operator not in FILTER_OPERATORS:
+            raise ValueError(
+                "Unsupported filter operator {!r}. Supported operators are: {}.".format(
+                    operator,
+                    ", ".join(FILTER_OPERATORS),
+                )
+            )
+        try:
+            numeric_threshold = float(threshold)
+        except (TypeError, ValueError):
+            raise ValueError(
+                "Invalid numeric threshold {!r} for filter column {!r}.".format(
+                    threshold,
+                    column,
+                )
+            )
         self.column = column
         self.operator = operator
-        self.threshold = threshold
+        self.comparator = FILTER_OPERATORS[operator]
+        self.threshold = numeric_threshold
         self.skip_value = skip_value

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -76,6 +76,22 @@ class FilterTests(unittest.TestCase):
             False
         ))
 
+    def test_not_equal(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            input_file = os.path.join(tmp_dir, "input.tsv")
+            output_file = os.path.join(tmp_dir, "output.tsv")
+            with open(input_file, "w") as input_fh:
+                input_fh.write("Score\n499\n500\n")
+
+            self.assertFalse(Filter(
+                input_file,
+                output_file,
+                [FilterCriterion("Score", "!=", "500")],
+            ).execute())
+
+            with open(output_file) as output_fh:
+                self.assertEqual("Score\n499\n", output_fh.read())
+
     def test_greater_or_equal(self):
         output_file = tempfile.NamedTemporaryFile()
         self.assertFalse(Filter(
@@ -155,6 +171,32 @@ class FilterTests(unittest.TestCase):
             os.path.join(self.test_data_path, "output.inf.tsv"),
             False
         ))
+
+    def test_invalid_operator(self):
+        with self.assertRaisesRegex(ValueError, "Unsupported filter operator"):
+            FilterCriterion(
+                "Median MT IC50 Score",
+                "__import__('os').system('true')",
+                "500",
+            )
+
+    def test_malicious_value_is_not_executed(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            marker_file = os.path.join(tmp_dir, "executed")
+            input_file = os.path.join(tmp_dir, "input.tsv")
+            output_file = os.path.join(tmp_dir, "output.tsv")
+            malicious_value = "__import__('pathlib').Path({!r}).touch() or 1".format(marker_file)
+            with open(input_file, "w") as input_fh:
+                input_fh.write("Score\n{}\n".format(malicious_value))
+
+            with self.assertRaisesRegex(ValueError, "Invalid numeric value"):
+                Filter(
+                    input_file,
+                    output_file,
+                    [FilterCriterion("Score", "<", "500")],
+                ).execute()
+
+            self.assertFalse(os.path.exists(marker_file))
 
     def test_conservative(self):
         output_file = tempfile.NamedTemporaryFile()


### PR DESCRIPTION
## Summary

- replace dynamic `eval()` use in tabular filtering with an explicit operator map
- parse filter values and thresholds as numeric input
- reject unsupported operators and malformed values with contextual errors
- add regression coverage for every supported comparison, invalid operators, and malicious input

## Why

Filter values originate in TSV data. Constructing and evaluating Python expressions from those values can execute unintended code and produces unclear failures for malformed input.

## Impact

Valid numeric filters retain their existing behavior, including `NA`, skipped values, and `inf`. Invalid operators and non-numeric values now fail deterministically.

## Validation

- `python -m unittest tests.test_filter` — 13 tests passed
- Python compile check passed for the changed source and test
- `git diff --check` passed

This is one focused replacement for part of #1430 and is based on `8.0.0`.

## AI assistance disclosure

This PR was AI-assisted using OpenAI Codex for implementation, test drafting, and command execution. I reviewed the diff line by line, ran the validation above, and take responsibility for the submitted changes.
