### PR TITLE
Parse transcript prioritization booleans explicitly

### DIFF
--- a/pvactools/lib/run_utils.py
+++ b/pvactools/lib/run_utils.py
@@ -100,22 +100,40 @@ def get_mutated_frameshift_peptide_with_flanking_sequence(wt_peptide, mt_peptide
         return
     return mutant_subsequence, wildtype_subsequence
 
+def _parse_transcript_boolean(value, column):
+    if pd.api.types.is_bool(value):
+        return bool(value)
+    if isinstance(value, str):
+        if value == 'True':
+            return True
+        if value == 'False':
+            return False
+        if value == 'Not Run':
+            return value
+    raise ValueError(
+        "Invalid value {!r} for {!r}. Expected True, False, or 'Not Run'.".format(
+            value,
+            column,
+        )
+    )
+
 def is_preferred_transcript(mutation, transcript_prioritization_strategy, maximum_transcript_support_level):
     if not isinstance(mutation, pd.Series):
         mutation = pd.Series(mutation)
-        if mutation['Canonical'] != 'Not Run':
-            mutation['Canonical'] = eval(mutation['Canonical'])
-        if mutation['MANE Select'] != 'Not Run':
-            mutation['MANE Select'] = eval(mutation['MANE Select'])
+        canonical = _parse_transcript_boolean(mutation['Canonical'], 'Canonical')
+        mane_select = _parse_transcript_boolean(mutation['MANE Select'], 'MANE Select')
+    else:
+        canonical = mutation['Canonical']
+        mane_select = mutation['MANE Select']
     if 'mane_select' in transcript_prioritization_strategy:
-        if mutation['MANE Select'] == 'Not Run':
+        if mane_select == 'Not Run':
             return True
-        elif mutation['MANE Select']:
+        elif mane_select:
             return True
     if 'canonical' in transcript_prioritization_strategy:
-        if mutation['Canonical'] == 'Not Run':
+        if canonical == 'Not Run':
             return True
-        elif mutation['Canonical']:
+        elif canonical:
             return True
     if 'tsl' in transcript_prioritization_strategy:
         col = 'TSL' if 'TSL' in mutation else 'Transcript Support Level'

--- a/tests/test_run_utils.py
+++ b/tests/test_run_utils.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 import py_compile
+import tempfile
 
 from pvactools.lib.run_utils import *
 from tests.utils import *
@@ -14,3 +15,55 @@ class RunUtilsTests(unittest.TestCase):
 
     def test_module_compiles(self):
         self.assertTrue(py_compile.compile(self.utils_path))
+
+    def test_is_preferred_transcript_accepts_boolean_values_and_strings(self):
+        for column, strategy in [
+            ('Canonical', 'canonical'),
+            ('MANE Select', 'mane_select'),
+        ]:
+            for value, expected in [
+                (True, True),
+                (False, False),
+                ('True', True),
+                ('False', False),
+                ('Not Run', True),
+            ]:
+                with self.subTest(column=column, value=value):
+                    mutation = {
+                        'Canonical': False,
+                        'MANE Select': False,
+                    }
+                    mutation[column] = value
+                    self.assertEqual(
+                        expected,
+                        is_preferred_transcript(mutation, [strategy], 1),
+                    )
+
+    def test_is_preferred_transcript_rejects_invalid_boolean_value(self):
+        for column, strategy in [
+            ('Canonical', 'canonical'),
+            ('MANE Select', 'mane_select'),
+        ]:
+            with self.subTest(column=column):
+                mutation = {
+                    'Canonical': False,
+                    'MANE Select': False,
+                }
+                mutation[column] = 'yes'
+                with self.assertRaises(ValueError) as context:
+                    is_preferred_transcript(mutation, [strategy], 1)
+                self.assertEqual(
+                    "Invalid value 'yes' for {!r}. Expected True, False, or 'Not Run'.".format(column),
+                    str(context.exception),
+                )
+
+    def test_is_preferred_transcript_does_not_execute_malicious_value(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            marker_file = os.path.join(tmp_dir, "executed")
+            mutation = {
+                'Canonical': "__import__('pathlib').Path({!r}).touch() or True".format(marker_file),
+                'MANE Select': False,
+            }
+            with self.assertRaisesRegex(ValueError, "Invalid value"):
+                is_preferred_transcript(mutation, ['canonical'], 1)
+            self.assertFalse(os.path.exists(marker_file))


### PR DESCRIPTION
## Summary

- replace `eval()` in transcript prioritization with explicit boolean parsing
- accept booleans plus the existing `True`, `False`, and `Not Run` string values
- reject unexpected values with a contextual error
- add regression coverage for valid, invalid, and malicious inputs

## Why

Transcript fields may originate in parsed tabular data. Evaluating their contents as Python can execute unintended code and treats malformed input unpredictably.

## Impact

Existing supported values preserve their behavior. Unexpected values now fail deterministically instead of being evaluated.

## Validation

- `python -m unittest tests.test_run_utils` — 4 tests passed
- Python compile check passed for the changed source and test
- `git diff --check` passed

This is one focused replacement for part of #1430 and is based on `8.0.0`.

## AI assistance disclosure

This PR was AI-assisted using OpenAI Codex for implementation, test drafting, and command execution. I reviewed the diff line by line, ran the validation above, and take responsibility for the submitted changes.
