### PR TITLE
Preserve AttributeError exceptions from CLI commands

### DIFF
--- a/pvactools/tools/main.py
+++ b/pvactools/tools/main.py
@@ -82,12 +82,11 @@ def main():
     if args[0].version is True:
         print(version('pvactools'))
     else:
-        try:
-            args[0].func.main(args[1])
-        except AttributeError as e:
+        if not hasattr(args[0], 'func'):
             parser.print_help()
             print("Error: No command specified")
             sys.exit(-1)
+        args[0].func.main(args[1])
 
 
 if __name__ == '__main__':

--- a/pvactools/tools/pvacbind/main.py
+++ b/pvactools/tools/pvacbind/main.py
@@ -106,12 +106,11 @@ def define_parser():
 def main():
     parser = define_parser()
     args = parser.parse_known_args()
-    try:
-        args[0].func.main(args[1])
-    except AttributeError as e:
+    if not hasattr(args[0], 'func'):
         parser.print_help()
         print("Error: No command specified")
         sys.exit(-1)
+    args[0].func.main(args[1])
 
 
 if __name__ == '__main__':

--- a/pvactools/tools/pvacfuse/main.py
+++ b/pvactools/tools/pvacfuse/main.py
@@ -126,12 +126,11 @@ def define_parser():
 def main():
     parser = define_parser()
     args = parser.parse_known_args()
-    try:
-        args[0].func.main(args[1])
-    except AttributeError as e:
+    if not hasattr(args[0], 'func'):
         parser.print_help()
         print("Error: No command specified")
         sys.exit(-1)
+    args[0].func.main(args[1])
 
 if __name__ == '__main__':
     main()

--- a/pvactools/tools/pvacseq/main.py
+++ b/pvactools/tools/pvacseq/main.py
@@ -161,12 +161,11 @@ def define_parser():
 def main():
     parser = define_parser()
     args = parser.parse_known_args()
-    try:
-        args[0].func.main(args[1])
-    except AttributeError as e:
+    if not hasattr(args[0], 'func'):
         parser.print_help()
         print("Error: No command specified")
         sys.exit(-1)
+    args[0].func.main(args[1])
 
 
 if __name__ == '__main__':

--- a/pvactools/tools/pvacsplice/main.py
+++ b/pvactools/tools/pvacsplice/main.py
@@ -137,12 +137,11 @@ def define_parser():
 def main():
     parser = define_parser()
     args = parser.parse_known_args()
-    try:
-        args[0].func.main(args[1])
-    except AttributeError as e:
+    if not hasattr(args[0], 'func'):
         parser.print_help()
         print("Error: No command specified")
         sys.exit(-1)
+    args[0].func.main(args[1])
 
 
 if __name__ == '__main__':

--- a/pvactools/tools/pvacvector/main.py
+++ b/pvactools/tools/pvacvector/main.py
@@ -33,12 +33,11 @@ def define_parser():
 def main():
     parser = define_parser()
     args = parser.parse_known_args()
-    try:
-        args[0].func.main(args[1])
-    except AttributeError as e:
+    if not hasattr(args[0], 'func'):
         parser.print_help()
         print("Error: No command specified")
         sys.exit(-1)
+    args[0].func.main(args[1])
 
 if __name__ == '__main__':
     main()

--- a/pvactools/tools/pvacview/main.py
+++ b/pvactools/tools/pvacview/main.py
@@ -23,12 +23,11 @@ def define_parser():
 def main():
     parser = define_parser()
     args = parser.parse_known_args()
-    try:
-        args[0].func.main(args[1])
-    except AttributeError as e:
+    if not hasattr(args[0], 'func'):
         parser.print_help()
         print("Error: No command specified")
         sys.exit(-1)
+    args[0].func.main(args[1])
 
 
 if __name__ == '__main__':

--- a/tests/test_cli_error_handling.py
+++ b/tests/test_cli_error_handling.py
@@ -1,0 +1,50 @@
+from contextlib import redirect_stdout
+import importlib
+from io import StringIO
+import sys
+import unittest
+from unittest.mock import patch
+
+
+CLI_COMMANDS = [
+    ('pvactools.tools.main', 'valid_alleles'),
+    ('pvactools.tools.pvacseq.main', 'run'),
+    ('pvactools.tools.pvacbind.main', 'run'),
+    ('pvactools.tools.pvacfuse.main', 'run'),
+    ('pvactools.tools.pvacsplice.main', 'run'),
+    ('pvactools.tools.pvacvector.main', 'run'),
+    ('pvactools.tools.pvacview.main', 'run'),
+]
+
+
+class CliErrorHandlingTests(unittest.TestCase):
+    def test_command_attribute_errors_are_not_hidden(self):
+        for module_name, command in CLI_COMMANDS:
+            with self.subTest(module=module_name):
+                cli_module = importlib.import_module(module_name)
+                command_module = getattr(cli_module, command)
+                argv = [module_name, command]
+                error = AttributeError('business failure')
+                with patch.object(sys, 'argv', argv), patch.object(
+                    command_module,
+                    'main',
+                    side_effect=error,
+                ):
+                    with self.assertRaises(AttributeError) as context:
+                        cli_module.main()
+                self.assertIs(context.exception, error)
+
+    def test_missing_commands_report_cli_error(self):
+        for module_name, _ in CLI_COMMANDS:
+            with self.subTest(module=module_name):
+                cli_module = importlib.import_module(module_name)
+                output = StringIO()
+                with patch.object(sys, 'argv', [module_name]), redirect_stdout(output):
+                    with self.assertRaises(SystemExit) as context:
+                        cli_module.main()
+                self.assertEqual(context.exception.code, -1)
+                self.assertIn('Error: No command specified', output.getvalue())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- detect a missing CLI subcommand before dispatch
- allow `AttributeError` raised by a selected command to propagate unchanged
- cover both behaviors across the top-level CLI and all product CLIs

## Why

The broad `AttributeError` handler currently treats command implementation failures as if no command was provided. This masks the real exception and replaces it with generic help output.

## Impact

Invocations without a command retain the current help and exit behavior. Runtime `AttributeError` exceptions from commands are no longer hidden.

## Validation

- `python -m unittest tests.test_cli_error_handling` — 2 tests passed with all seven CLIs exercised as subtests
- Python compile check passed for the changed CLI modules and test
- `git diff --check` passed

This is one focused replacement for part of #1430 and is based on `8.0.0`.

## AI assistance disclosure

This PR was AI-assisted using OpenAI Codex for implementation, test drafting, and command execution. I reviewed the diff line by line, ran the validation above, and take responsibility for the submitted changes.
