### PR TITLE
Fix command mentions of the allele_specific_cutoffs command

### DIFF
--- a/docs/pvacbind/filter_commands.rst
+++ b/docs/pvacbind/filter_commands.rst
@@ -48,7 +48,7 @@ prediction's HLA allele are used instead of the value set via the ``--binding-th
 For HLA alleles where no allele-specific binding threshold is available, the
 binding threshold is used as a fallback. Alleles with allele-specific
 threshold as well as the value of those thresholds can be printed by executing
-the ``pvacbind allele_specific_cutoffs`` command.
+the ``pvactools allele_specific_cutoffs`` command.
 
 In addition to being able to filter on the IC50 score columns, the binding
 filter also offers the ability to filter on the percentile score using the

--- a/docs/pvacbind/output_files.rst
+++ b/docs/pvacbind/output_files.rst
@@ -237,7 +237,7 @@ provided to the pVACfuse run:
        allele-specific binding thresholds. For alleles where no
        allele-specific binding threshold is available, use the
        ``--binding-threshold`` as a fallback. To print a list of alleles that have
-       specific binding thresholds and the value of those thresholds, run ``pvacfuse allele_specific_cutoffs``.
+       specific binding thresholds and the value of those thresholds, run ``pvactools allele_specific_cutoffs``.
      - False
    * - ``--binding-percentile-threshold``
      - Use this threshold to filter epitopes on the IC50 %ile MT score.

--- a/docs/pvacfuse/filter_commands.rst
+++ b/docs/pvacfuse/filter_commands.rst
@@ -47,7 +47,7 @@ prediction's HLA allele are used instead of the value set via the ``--binding-th
 For HLA alleles where no allele-specific binding threshold is available, the
 binding threshold is used as a fallback. Alleles with allele-specific
 threshold as well as the value of those thresholds can be printed by executing
-the ``pvacfuse allele_specific_cutoffs`` command.
+the ``pvactools allele_specific_cutoffs`` command.
 
 In addition to being able to filter on the IC50 score columns, the binding
 filter also offers the ability to filter on the percentile score using the

--- a/docs/pvacfuse/output_files.rst
+++ b/docs/pvacfuse/output_files.rst
@@ -275,7 +275,7 @@ provided to the pVACfuse run:
        allele-specific binding thresholds. For alleles where no
        allele-specific binding threshold is available, use the
        ``--binding-threshold`` as a fallback. To print a list of alleles that have
-       specific binding thresholds and the value of those thresholds, run ``pvacfuse allele_specific_cutoffs``.
+       specific binding thresholds and the value of those thresholds, run ``pvactools allele_specific_cutoffs``.
      - False
    * - ``--binding-percentile-threshold``
      - Use this threshold to filter epitopes on the IC50 %ile MT score.

--- a/docs/pvacseq/filter_commands.rst
+++ b/docs/pvacseq/filter_commands.rst
@@ -56,7 +56,7 @@ prediction's HLA allele are used instead of the value set via the ``--binding-th
 For HLA alleles where no allele-specific binding threshold is available, the
 binding threshold is used as a fallback. Alleles with allele-specific
 threshold as well as the value of those thresholds can be printed by executing
-the ``pvacseq allele_specific_cutoffs`` command.
+the ``pvactools allele_specific_cutoffs`` command.
 
 The binding filter also offers the option to filter on ``Fold Change`` columns, which contain
 the ratio of the MT score to the WT Score. This option can be activated by setting the
@@ -189,7 +189,7 @@ prediction's HLA allele are used instead of the value set via the ``--binding-th
 For HLA alleles where no allele-specific binding threshold is available, the
 binding threshold is used as a fallback. Alleles with allele-specific
 threshold as well as the value of those thresholds can be printed by executing
-the ``pvacseq allele_specific_cutoffs`` command.
+the ``pvactools allele_specific_cutoffs`` command.
 
 **Additional Considerations**
 

--- a/docs/pvacseq/output_files.rst
+++ b/docs/pvacseq/output_files.rst
@@ -489,7 +489,7 @@ To tier the Best Peptide, several cutoffs can be adjusted using arguments provid
        allele-specific binding thresholds. For alleles where no
        allele-specific binding threshold is available, use the
        ``--binding-threshold`` as a fallback. To print a list of alleles that have
-       specific binding thresholds and the value of those thresholds, run ``pvacseq allele_specific_cutoffs``.
+       specific binding thresholds and the value of those thresholds, run ``pvactools allele_specific_cutoffs``.
      - False
    * - ``--binding-percentile-threshold``
      - Use this threshold to filter epitopes on the IC50 %ile MT score.

--- a/docs/pvacsplice/filter_commands.rst
+++ b/docs/pvacsplice/filter_commands.rst
@@ -52,7 +52,7 @@ prediction's HLA allele are used instead of the value set via the ``--binding-th
 For HLA alleles where no allele-specific binding threshold is available, the
 binding threshold is used as a fallback. Alleles with allele-specific
 threshold as well as the value of those thresholds can be printed by executing
-the ``pvacsplice allele_specific_cutoffs`` command.
+the ``pvactools allele_specific_cutoffs`` command.
 
 In addition to being able to filter on the IC50 score columns, the binding
 filter also offers the ability to filter on the percentile score using the

--- a/docs/pvacsplice/output_files.rst
+++ b/docs/pvacsplice/output_files.rst
@@ -384,7 +384,7 @@ To tier the Best Peptide, several cutoffs can be adjusted using arguments provid
        allele-specific binding thresholds. For alleles where no
        allele-specific binding threshold is available, use the
        ``--binding-threshold`` as a fallback. To print a list of alleles that have
-       specific binding thresholds and the value of those thresholds, run ``pvacseq allele_specific_cutoffs``.
+       specific binding thresholds and the value of those thresholds, run ``pvactools allele_specific_cutoffs``.
      - False
    * - ``--binding-percentile-threshold``
      - Use this threshold to filter epitopes on the IC50 %ile MT score.

--- a/pvactools/lib/binding_filter.py
+++ b/pvactools/lib/binding_filter.py
@@ -155,7 +155,7 @@ class BindingFilter:
         )
         parser.add_argument(
             '-a', '--allele-specific-binding-thresholds',
-            help="Use allele-specific binding thresholds. To print the allele-specific binding thresholds run `%s allele_specific_cutoffs`. " % tool
+            help="Use allele-specific binding thresholds. To print the allele-specific binding thresholds run `pvactools allele_specific_cutoffs`. "
                  + "If an allele does not have a special threshold value, the `--binding-threshold` value will be used.",
             default=False,
             action='store_true',

--- a/pvactools/lib/run_argument_parser.py
+++ b/pvactools/lib/run_argument_parser.py
@@ -139,7 +139,7 @@ class RunArgumentParser(metaclass=ABCMeta):
         )
         self.parser.add_argument(
             '--allele-specific-binding-thresholds',
-            help="Use allele-specific binding thresholds. To print the allele-specific binding thresholds run `%s allele_specific_cutoffs`. " % tool_name
+            help="Use allele-specific binding thresholds. To print the allele-specific binding thresholds run `pvactools allele_specific_cutoffs`. "
                  + "If an allele does not have a special threshold value, the `--binding-threshold` value will be used.",
             default=False,
             action='store_true',
@@ -606,7 +606,7 @@ class PvacvectorRunArgumentParser(RunArgumentParser):
         )
         self.parser.add_argument(
             '--allele-specific-binding-thresholds',
-            help="Use allele-specific binding thresholds when evaluating junctional epitopes. To print the allele-specific binding thresholds run `pvacvector allele_specific_cutoffs`. "
+            help="Use allele-specific binding thresholds when evaluating junctional epitopes. To print the allele-specific binding thresholds run `pvactools allele_specific_cutoffs`. "
                  + "If an allele does not have a special threshold value, the `--binding-threshold` value will be used.",
             default=False,
             action='store_true',

--- a/pvactools/lib/update_tiers.py
+++ b/pvactools/lib/update_tiers.py
@@ -76,7 +76,7 @@ class UpdateTiers:
         )
         parser.add_argument(
             '--allele-specific-binding-thresholds',
-            help="Use allele-specific binding thresholds when evaluating the binding criteria for tiering. To print the allele-specific binding thresholds run `%s allele_specific_cutoffs`. " % tool
+            help="Use allele-specific binding thresholds when evaluating the binding criteria for tiering. To print the allele-specific binding thresholds run `pvactools allele_specific_cutoffs`. "
                  + "If an allele does not have a special threshold value, the `--binding-threshold` value will be used.",
             default=False,
             action='store_true',

--- a/pvactools/tools/pvacbind/generate_aggregated_report.py
+++ b/pvactools/tools/pvacbind/generate_aggregated_report.py
@@ -28,7 +28,7 @@ def define_parser():
     )
     parser.add_argument(
         '--allele-specific-binding-thresholds',
-        help="Use allele-specific binding thresholds. To print the allele-specific binding thresholds run `pvacbind allele_specific_cutoffs`. "
+        help="Use allele-specific binding thresholds. To print the allele-specific binding thresholds run `pvactools allele_specific_cutoffs`. "
              + "If an allele does not have a special threshold value, the `--binding-threshold` value will be used.",
         default=False,
         action='store_true',

--- a/pvactools/tools/pvacfuse/generate_aggregated_report.py
+++ b/pvactools/tools/pvacfuse/generate_aggregated_report.py
@@ -28,7 +28,7 @@ def define_parser():
     )
     parser.add_argument(
         '--allele-specific-binding-thresholds',
-        help="Use allele-specific binding thresholds. To print the allele-specific binding thresholds run `pvacfuse allele_specific_cutoffs`. "
+        help="Use allele-specific binding thresholds. To print the allele-specific binding thresholds run `pvactools allele_specific_cutoffs`. "
              + "If an allele does not have a special threshold value, the `--binding-threshold` value will be used.",
         default=False,
         action='store_true',

--- a/pvactools/tools/pvacseq/generate_aggregated_report.py
+++ b/pvactools/tools/pvacseq/generate_aggregated_report.py
@@ -32,7 +32,7 @@ def define_parser():
     )
     parser.add_argument(
         '--allele-specific-binding-thresholds',
-        help="Use allele-specific binding thresholds. To print the allele-specific binding thresholds run `pvacseq allele_specific_cutoffs`. "
+        help="Use allele-specific binding thresholds. To print the allele-specific binding thresholds run `pvactools allele_specific_cutoffs`. "
              + "If an allele does not have a special threshold value, the `--binding-threshold` value will be used.",
         default=False,
         action='store_true',

--- a/pvactools/tools/pvacsplice/generate_aggregated_report.py
+++ b/pvactools/tools/pvacsplice/generate_aggregated_report.py
@@ -32,7 +32,7 @@ def define_parser():
     )
     parser.add_argument(
         '--allele-specific-binding-thresholds',
-        help="Use allele-specific binding thresholds. To print the allele-specific binding thresholds run `pvacseq allele_specific_cutoffs`. "
+        help="Use allele-specific binding thresholds. To print the allele-specific binding thresholds run `pvactools allele_specific_cutoffs`. "
              + "If an allele does not have a special threshold value, the `--binding-threshold` value will be used.",
         default=False,
         action='store_true',


### PR DESCRIPTION
In various places we were still referencing the previous command line tree of the `allele_specific_cutoffs` command (`pvacseq|fuse|splice|bind allele_specific_cutoffs` instead of `pvactools allele_specific_cutoffs`). This PR fixes that.