### PR TITLE
Fix issue in the Transcript Pass logic that would cause pVACview to crash on retiering

### DIFF
--- a/pvactools/tools/pvacview/input_processing_functions.R
+++ b/pvactools/tools/pvacview/input_processing_functions.R
@@ -91,20 +91,7 @@ set_formatting_columns <- function(df) {
     df$mainTable$`RNA VAF Fail` <- apply(df$mainTable, 1, function(x) {!is.na(x['RNA VAF']) && as.numeric(x['RNA VAF']) <= as.numeric(df$metricsData['trna_vaf'])})
     df$mainTable$`RNA Depth Fail` <- apply(df$mainTable, 1, function(x) {!is.na(x['RNA Depth']) && as.numeric(x['RNA Depth']) <= as.numeric(df$metricsData['trna_cov'])})
     df$mainTable$`Prob Pos Pass` <- apply(df$mainTable, 1, function(x) {is_probaa_pass(x["Prob Pos"])})
-    transcript_pass <- apply(df$mainTable, 1, function(x) {
-      if ('tsl' %in% df$transcript_prioritization_strategy && is_tsl_pass(x["TSL"], as.numeric(df$maximum_transcript_support_level))) {
-        return("True")
-      }
-      else if ('mane_select' %in% df$transcript_prioritization_strategy && is_mane_select_pass(x["MANE Select"])) {
-        return("True")
-      }
-      else if ('canonical' %in% df$transcript_prioritization_strategy && is_canonical_pass(x["Canonical"])) {
-        return("True")
-      }
-      else {
-        return("False")
-      }
-    })
+    transcript_pass <- apply(df$mainTable, 1, function(x) { ifelse(is_transcript_pass(x["Canonical"], x["MANE Select"], x["TSL"], df$transcript_prioritization_strategy, df$maximum_transcript_support_level), "True", "False") })
     df$mainTable <- add_column(df$mainTable, `Transcript Pass` = transcript_pass, .after = "TSL")
     return (df)
 }

--- a/pvactools/tools/pvacview/server.R
+++ b/pvactools/tools/pvacview/server.R
@@ -348,19 +348,7 @@ server <- shinyServer(function(input, output, session) {
     df$mainTable$`RNA VAF Fail` <- apply(df$mainTable, 1, function(x) {!is.na(x['RNA VAF']) && as.numeric(x['RNA VAF']) <= as.numeric(df$metricsData['trna_vaf'])})
     df$mainTable$`RNA Depth Fail` <- apply(df$mainTable, 1, function(x) {!is.na(x['RNA Depth']) && as.numeric(x['RNA Depth']) <= as.numeric(df$metricsData['trna_cov'])})
     df$mainTable$`Prob Pos Pass` <- apply(df$mainTable, 1, function(x) {is_probaa_pass(x["Prob Pos"])})
-    transcript_pass <- apply(df$mainTable, TRUE, function(x) {
-      if ('tsl' %in% df$transcript_prioritization_strategy && is_tsl_pass(x["TSL"], as.numeric(df$maximum_transcript_support_level))) {
-        return("True")
-      }
-      if ('mane_select' %in% df$transcript_prioritization_strategy && is_mane_select_pass(x["MANE Select"])) {
-        return("True")
-      }
-      if ('canonical' %in% df$transcript_prioritization_strategy && is_canonical_pass(x["Canonical"])) {
-        return("True")
-      }
-      return("False")
-    })
-    df$mainTable <- add_column(df$mainTable, `Transcript Pass` = transcript_pass, .after = "TSL")
+    df$mainTable$`Transcript Pass` <- apply(df$mainTable, 1, function(x) { ifelse(is_transcript_pass(x["Canonical"], x["MANE Select"], x["TSL"], df$transcript_prioritization_strategy, df$maximum_transcript_support_level), "True", "False") })
     tier_sorter <- c("Pass", "PoorBinder", "PoorImmunogenicity", "PoorPresentation", "RefMatch", "PoorTranscript", "LowExpr", "Anchor", "Subclonal", "ProbPos", "Poor", "NoExpr")
     df$mainTable$`Rank` <- rank(desc(as.numeric(replace(df$mainTable$`Allele Expr`, is.na(df$mainTable$`Allele Expr`), 0))), ties.method = "first")
     for (metric in df$scoring_candidate_metric) {
@@ -420,19 +408,7 @@ server <- shinyServer(function(input, output, session) {
     df$mainTable$`RNA VAF Fail` <- apply(df$mainTable, 1, function(x) {!is.na(x['RNA VAF']) && as.numeric(x['RNA VAF']) <= as.numeric(df$metricsData['trna_vaf'])})
     df$mainTable$`RNA Depth Fail` <- apply(df$mainTable, 1, function(x) {!is.na(x['RNA Depth']) && as.numeric(x['RNA Depth']) <= as.numeric(df$metricsData['trna_cov'])})
     df$mainTable$`Prob Pos Pass` <- apply(df$mainTable, 1, function(x) {is_probaa_pass(x["Prob Pos"])})
-    transcript_pass <- apply(df$mainTable, TRUE, function(x) {
-      if ('tsl' %in% df$transcript_prioritization_strategy && is_tsl_pass(x["TSL"], as.numeric(df$maximum_transcript_support_level))) {
-        return("True")
-      }
-      if ('mane_select' %in% df$transcript_prioritization_strategy && is_mane_select_pass(x["MANE Select"])) {
-        return("True")
-      }
-      if ('canonical' %in% df$transcript_prioritization_strategy && is_canonical_pass(x["Canonical"])) {
-        return("True")
-      }
-      return("False")
-    })
-    df$mainTable <- add_column(df$mainTable, `Transcript Pass` = transcript_pass, .after = "TSL")
+    df$mainTable$`Transcript Pass` <- apply(df$mainTable, 1, function(x) { ifelse(is_transcript_pass(x["Canonical"], x["MANE Select"], x["TSL"], df$transcript_prioritization_strategy, df$maximum_transcript_support_level), "True", "False") })
     tier_sorter <- c("Pass", "PoorBinder", "PoorImmunogenicity", "PoorPresentation", "RefMatch", "PoorTranscript", "LowExpr", "Anchor", "Subclonal", "ProbPos", "Poor", "NoExpr")
     df$mainTable$`Rank` <- rank(desc(as.numeric(replace(df$mainTable$`Allele Expr`, is.na(df$mainTable$`Allele Expr`), 0))), ties.method = "first")
     for (metric in df$scoring_candidate_metric) {


### PR DESCRIPTION
Using `apply(df$mainTable, TRUE ...` instead of `apply(df$mainTable, 1 ...` when calculating `transcript_pass` status would cause pVACview to crash during re-tiering. This PR fixes that. It also centralizes the logic for this status by re-using the existing `is_transcript_pass` function. Additionally, the exiting logic to add a new column for the results of this function during retiering would result in a second Transcript Pass column to be appended instead of the existing column to be updated. This PR fixes that.